### PR TITLE
NSCoding compliance of RVCollectionViewLayout

### DIFF
--- a/RouletteViewDemo/RVCollectionViewLayout.m
+++ b/RouletteViewDemo/RVCollectionViewLayout.m
@@ -23,6 +23,19 @@
     return self;
 }
 
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        self.itemSize = CGSizeMake(100.0f, 153.0f);
+        self.sectionInset = UIEdgeInsetsMake(0, 60, 0, 60);
+        self.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    }
+    return self;
+}
+
+- (void)prepareLayout {
+    self.superView = self.collectionView.superview;
+}
 /**
 This method is called by UICollectionView for laying out cells in the visible rect.
  */

--- a/RouletteViewDemo/RVViewController.m
+++ b/RouletteViewDemo/RVViewController.m
@@ -30,11 +30,6 @@
     self.collectionView.showsHorizontalScrollIndicator = NO;
     self.collectionView.showsVerticalScrollIndicator = NO;
     self.collectionView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    self.collectionView.delegate = self;
-    
-    self.collectionViewLayout = [[RVCollectionViewLayout alloc] init];
-    self.collectionViewLayout.superView = self.view;
-    [self.collectionView setCollectionViewLayout:self.collectionViewLayout];
 }
 
 #pragma mark - UICollectionViewDataSource


### PR DESCRIPTION
This patch adds the implementation of initializer `-initWithCoder:` to support Interface Builder integration.

As a connected outlet in the xib, the layout instance no longer needs to be created programatically.

The property `superView` is fetched in `-prepareLayout`, rendering the controller code more concise.
